### PR TITLE
testing cases that illustrate how to handle api limits potentially

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -31,7 +31,7 @@ jobs:
         run: poetry install
 
       - name: Test with pytest
-        run: poetry run pytest tests/ --cov=firehose_pyio --cov-report=xml -W ignore::pytest.PytestCollectionWarning
+        run: poetry run pytest tests/ -svv --cov=firehose_pyio --cov-report=xml -W ignore::pytest.PytestCollectionWarning
 
       - name: Use Codecov to track coverage
         uses: codecov/codecov-action@v3

--- a/tests/test_io.py
+++ b/tests/test_io.py
@@ -20,7 +20,9 @@ import boto3
 from moto import mock_aws
 from moto.core import DEFAULT_ACCOUNT_ID as ACCOUNT_ID
 import apache_beam as beam
+from apache_beam import GroupIntoBatches
 from apache_beam.options import pipeline_options
+from apache_beam.transforms.util import BatchElements
 from apache_beam.testing.test_pipeline import TestPipeline
 from apache_beam.testing.util import assert_that, equal_to
 
@@ -83,17 +85,6 @@ class TestWriteToFirehose(unittest.TestCase):
             ]
         )
 
-    def test_write_to_firehose_with_unsupported_types(self):
-        # accepts iterable except for string
-        with self.assertRaises(TypeError):
-            with TestPipeline(options=self.pipeline_opts) as p:
-                (
-                    p
-                    | beam.Create(["one", "two", "three", "four"])
-                    | WriteToFirehose(self.delivery_stream_name, True)
-                    | beam.Map(lambda e: e["FailedPutCount"])
-                )
-
     def test_write_to_firehose_with_invalid_typed_list_elements(self):
         # parameter validation error if not <class 'bytes'>, <class 'bytearray'>, file-like object
         with self.assertRaises(Boto3ClientError):
@@ -133,4 +124,62 @@ class TestWriteToFirehose(unittest.TestCase):
         bucket_contents = collect_bucket_contents(self.s3_client, self.bucket_name)
         self.assertSetEqual(
             set(bucket_contents), set(['"one""two""three""four"', "1234"])
+        )
+
+    def test_write_to_firehose_with_unsupported_elements(self):
+        # accepts iterable objects except for string
+        with self.assertRaises(TypeError):
+            with TestPipeline(options=self.pipeline_opts) as p:
+                (
+                    p
+                    | beam.Create(["one", "two", "three", "four"])
+                    | WriteToFirehose(self.delivery_stream_name, False)
+                    | beam.Map(lambda e: e["FailedPutCount"])
+                )
+    
+    def test_write_to_firehose_with_group_unsupported_elements_into_batches(self):
+        # string is not a supported type but list of strings
+        # convert to list of strings with BatchElements if unkeyed elements
+        with TestPipeline(options=self.pipeline_opts) as p:
+            output = (
+                p
+                | beam.Create(["one", "two", "three", "four"])
+                | BatchElements(min_batch_size=2, max_batch_size=2)
+                | WriteToFirehose(self.delivery_stream_name, False)
+                | beam.Map(lambda e: e["FailedPutCount"])
+            )
+            assert_that(output, equal_to([0, 0]))
+
+        bucket_contents = collect_bucket_contents(self.s3_client, self.bucket_name)
+        self.assertSetEqual(
+            set(bucket_contents), set(['onetwo', 'threefour'])
+        )
+
+    def test_write_to_firehose_with_unsupported_tuple_elements(self):
+        # accepts iterable objects except for string
+        with self.assertRaises(TypeError):
+            with TestPipeline(options=self.pipeline_opts) as p:
+                (
+                    p
+                    | beam.Create([(1, "one"), (2, "two"), (1, "three"), (2, "four")])
+                    | WriteToFirehose(self.delivery_stream_name, False)
+                    | beam.Map(lambda e: e["FailedPutCount"])
+                )
+
+    def test_write_to_firehose_with_group_unsupported_tuple_elements_into_batches(self):
+        # string is not a supported type but list of strings
+        # convert to list of strings with GroupIntoBatches if keyed elements
+        with TestPipeline(options=self.pipeline_opts) as p:
+            output = (
+                p
+                | beam.Create([(1, "one"), (2, "three"), (1, "two"), (2, "four")])
+                | GroupIntoBatches(batch_size=2)
+                | WriteToFirehose(self.delivery_stream_name, False)
+                | beam.Map(lambda e: e["FailedPutCount"])
+            )
+            assert_that(output, equal_to([0, 0]))
+
+        bucket_contents = collect_bucket_contents(self.s3_client, self.bucket_name)
+        self.assertSetEqual(
+            set(bucket_contents), set(['onetwo', 'threefour'])
         )


### PR DESCRIPTION
Instead of handling api limits, inform users of how to use GroupIntoBatches and GroupElements.