### PR TITLE
Feature/prepare 0.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,11 +2,23 @@
 
 <!--next-version-placeholder-->
 
+## v0.2.0 (22/08/2024)
+
+♻️UPDATE
+
+- Return failed elements by a tagged output, which allows users to determine how to handle them subsequently.
+- Provide options that handle failed records.
+  - _max_trials_ - The maximum number of trials when there is one or more failed records.
+  - _append_error_ - Whether to append error details to failed records.
+
 ## v0.1.0 (23/07/2024)
 
 ✨NEW
 
 - Add a composite transform (`WriteToFirehose`) that puts records into a Firehose delivery stream in batch, using the [`put_record_batch`](https://boto3.amazonaws.com/v1/documentation/api/latest/reference/services/firehose/client/put_record_batch.html) method of the boto3 package.
+- Provide options that control individual records.
+  - _jsonify_ - A flag that indicates whether to convert a record into JSON. Note that a record should be of _bytes_, _bytearray_ or file-like object, and, if it is not of a supported type (e.g. integer), we can convert it into a Json string by specifying this flag to _True_.
+  - _multiline_ - A flag that indicates whether to add a new line character (`\n`) to each record. It is useful to save records into a _CSV_ or _Jsonline_ file.
 - Create a dedicated pipeline option (`FirehoseOptions`) that reads AWS related values (e.g. `aws_access_key_id`) from pipeline arguments.
 - Implement metric objects that record the total, succeeded and failed elements counts.
 - Add unit and integration testing cases. The [moto](https://github.com/getmoto/moto) and [localstack-utils](https://docs.localstack.cloud/user-guide/tools/testing-utils/) packages are used for unit and integration testing respectively. Also, a custom test client is created for testing retry of failed elements, which is not supported by the moto package.

--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ Interested in contributing? Check out the contributing guidelines. Please note t
 
 ## License
 
-`firehose_pyio` was created by Beam PyIO <beam.pyio@gmail.com>. It is licensed under the terms of the Apache License 2.0 license.
+`firehose_pyio` was created as part of the [Apache Beam Python I/O Connectors](https://github.com/beam-pyio) project. It is licensed under the terms of the Apache License 2.0 license.
 
 ## Credits
 

--- a/src/firehose_pyio/boto3_client.py
+++ b/src/firehose_pyio/boto3_client.py
@@ -122,7 +122,6 @@ class FirehoseClient(object):
 
         Raises:
             FirehoseClientError: Firehose client error.
-            TypeError: TypeError.
 
         Returns:
             (Object): Boto3 response message.
@@ -136,7 +135,7 @@ class FirehoseClient(object):
             return record
 
         if not isinstance(records, list):
-            raise TypeError("Records should be a list.")
+            raise FirehoseClientError("Records should be a list.")
         try:
             boto_response = self.client.put_record_batch(
                 DeliveryStreamName=delivery_stream_name,
@@ -166,7 +165,7 @@ class FakeFirehoseClient:
         self, records: list, delivery_stream_name: str, jsonify: bool, multiline: bool
     ):
         if not isinstance(records, list):
-            raise TypeError("Records should be a list.")
+            raise FirehoseClientError("Records should be a list.")
         request_responses = []
         for index, _ in enumerate(records):
             if index < self.num_success:

--- a/tests/boto3_client_test.py
+++ b/tests/boto3_client_test.py
@@ -73,7 +73,7 @@ class TestBoto3Client(unittest.TestCase):
     def test_put_record_batch_with_unsupported_types(self):
         # only the list type is supported!
         self.assertRaises(
-            TypeError,
+            FirehoseClientError,
             self.fh_client.put_record_batch,
             "abc",
             self.delivery_stream_name,
@@ -82,7 +82,7 @@ class TestBoto3Client(unittest.TestCase):
         )
 
         self.assertRaises(
-            TypeError,
+            FirehoseClientError,
             self.fh_client.put_record_batch,
             123,
             self.delivery_stream_name,

--- a/tests/io_it_test.py
+++ b/tests/io_it_test.py
@@ -121,7 +121,7 @@ class TestWriteToFirehose(unittest.TestCase):
                 | BatchElements(min_batch_size=2, max_batch_size=2)
                 | WriteToFirehose(self.delivery_stream_name, False, False)
             )
-            assert_that(output, equal_to([]))
+            assert_that(output[None], equal_to([]))
 
         bucket_contents = collect_bucket_contents(self.bucket_name)
         self.assertSetEqual(set(bucket_contents), set(["onetwo", "threefour"]))
@@ -134,7 +134,7 @@ class TestWriteToFirehose(unittest.TestCase):
                 | GroupIntoBatches(batch_size=2)
                 | WriteToFirehose(self.delivery_stream_name, False, False)
             )
-            assert_that(output, equal_to([]))
+            assert_that(output[None], equal_to([]))
 
         bucket_contents = collect_bucket_contents(self.bucket_name)
         self.assertSetEqual(set(bucket_contents), set(["onetwo", "threefour"]))
@@ -147,7 +147,7 @@ class TestWriteToFirehose(unittest.TestCase):
                 | BatchElements(min_batch_size=2, max_batch_size=2)
                 | WriteToFirehose(self.delivery_stream_name, False, True)
             )
-            assert_that(output, equal_to([]))
+            assert_that(output[None], equal_to([]))
 
         bucket_contents = collect_bucket_contents(self.bucket_name)
         self.assertSetEqual(set(bucket_contents), set(["one\ntwo\n", "three\nfour\n"]))
@@ -160,7 +160,7 @@ class TestWriteToFirehose(unittest.TestCase):
                 | GroupIntoBatches(batch_size=2)
                 | WriteToFirehose(self.delivery_stream_name, False, True)
             )
-            assert_that(output, equal_to([]))
+            assert_that(output[None], equal_to([]))
 
         bucket_contents = collect_bucket_contents(self.bucket_name)
         self.assertSetEqual(set(bucket_contents), set(["one\ntwo\n", "three\nfour\n"]))

--- a/tests/io_test.py
+++ b/tests/io_test.py
@@ -86,7 +86,7 @@ class TestWriteToFirehose(unittest.TestCase):
 
     def test_write_to_firehose_with_unsupported_types(self):
         # only the list type is supported!
-        with self.assertRaises(TypeError):
+        with self.assertRaises(FirehoseClientError):
             with TestPipeline(options=self.pipeline_opts) as p:
                 (
                     p
@@ -134,7 +134,7 @@ class TestWriteToFirehose(unittest.TestCase):
 
     def test_write_to_firehose_without_list_to_batch_elements(self):
         # accepts iterable objects except for string
-        with self.assertRaises(TypeError):
+        with self.assertRaises(FirehoseClientError):
             with TestPipeline(options=self.pipeline_opts) as p:
                 (
                     p
@@ -159,7 +159,7 @@ class TestWriteToFirehose(unittest.TestCase):
 
     def test_write_to_firehose_without_tuple_to_group_into_batches(self):
         # accepts iterable objects except for string
-        with self.assertRaises(TypeError):
+        with self.assertRaises(FirehoseClientError):
             with TestPipeline(options=self.pipeline_opts) as p:
                 (
                     p

--- a/tests/io_test.py
+++ b/tests/io_test.py
@@ -91,7 +91,11 @@ class TestWriteToFirehose(unittest.TestCase):
                 (
                     p
                     | beam.Create(["one", "two", "three", "four"])
-                    | WriteToFirehose(self.delivery_stream_name, True, False)
+                    | WriteToFirehose(
+                        delivery_stream_name=self.delivery_stream_name,
+                        jsonify=False,
+                        multiline=False,
+                    )
                 )
 
     def test_write_to_firehose_with_invalid_typed_list_elements(self):
@@ -101,7 +105,11 @@ class TestWriteToFirehose(unittest.TestCase):
                 (
                     p
                     | beam.Create([[1, 2, 3, 4]])
-                    | WriteToFirehose(self.delivery_stream_name, False, False)
+                    | WriteToFirehose(
+                        delivery_stream_name=self.delivery_stream_name,
+                        jsonify=False,
+                        multiline=False,
+                    )
                 )
 
     def test_write_to_firehose_with_list_elements(self):
@@ -109,9 +117,13 @@ class TestWriteToFirehose(unittest.TestCase):
             output = (
                 p
                 | beam.Create([["one", "two", "three", "four"], [1, 2, 3, 4]])
-                | WriteToFirehose(self.delivery_stream_name, True, False)
+                | WriteToFirehose(
+                    delivery_stream_name=self.delivery_stream_name,
+                    jsonify=True,
+                    multiline=False,
+                )
             )
-            assert_that(output, equal_to([]))
+            assert_that(output[None], equal_to([]))
 
         bucket_contents = collect_bucket_contents(self.s3_client, self.bucket_name)
         self.assertSetEqual(
@@ -123,9 +135,13 @@ class TestWriteToFirehose(unittest.TestCase):
             output = (
                 p
                 | beam.Create([(1, ["one", "two", "three", "four"]), (2, [1, 2, 3, 4])])
-                | WriteToFirehose(self.delivery_stream_name, True, False)
+                | WriteToFirehose(
+                    delivery_stream_name=self.delivery_stream_name,
+                    jsonify=True,
+                    multiline=False,
+                )
             )
-            assert_that(output, equal_to([]))
+            assert_that(output[None], equal_to([]))
 
         bucket_contents = collect_bucket_contents(self.s3_client, self.bucket_name)
         self.assertSetEqual(
@@ -139,7 +155,11 @@ class TestWriteToFirehose(unittest.TestCase):
                 (
                     p
                     | beam.Create(["one", "two", "three", "four"])
-                    | WriteToFirehose(self.delivery_stream_name, False, False)
+                    | WriteToFirehose(
+                        delivery_stream_name=self.delivery_stream_name,
+                        jsonify=False,
+                        multiline=False,
+                    )
                 )
 
     def test_write_to_firehose_with_list_to_batch_elements(self):
@@ -150,9 +170,13 @@ class TestWriteToFirehose(unittest.TestCase):
                 p
                 | beam.Create(["one", "two", "three", "four"])
                 | BatchElements(min_batch_size=2, max_batch_size=2)
-                | WriteToFirehose(self.delivery_stream_name, False, False)
+                | WriteToFirehose(
+                    delivery_stream_name=self.delivery_stream_name,
+                    jsonify=False,
+                    multiline=False,
+                )
             )
-            assert_that(output, equal_to([]))
+            assert_that(output[None], equal_to([]))
 
         bucket_contents = collect_bucket_contents(self.s3_client, self.bucket_name)
         self.assertSetEqual(set(bucket_contents), set(["onetwo", "threefour"]))
@@ -164,7 +188,11 @@ class TestWriteToFirehose(unittest.TestCase):
                 (
                     p
                     | beam.Create([(1, "one"), (2, "two"), (1, "three"), (2, "four")])
-                    | WriteToFirehose(self.delivery_stream_name, False, False)
+                    | WriteToFirehose(
+                        delivery_stream_name=self.delivery_stream_name,
+                        jsonify=False,
+                        multiline=False,
+                    )
                 )
 
     def test_write_to_firehose_with_tuple_to_group_into_batches(self):
@@ -175,9 +203,13 @@ class TestWriteToFirehose(unittest.TestCase):
                 p
                 | beam.Create([(1, "one"), (2, "three"), (1, "two"), (2, "four")])
                 | GroupIntoBatches(batch_size=2)
-                | WriteToFirehose(self.delivery_stream_name, False, False)
+                | WriteToFirehose(
+                    delivery_stream_name=self.delivery_stream_name,
+                    jsonify=False,
+                    multiline=False,
+                )
             )
-            assert_that(output, equal_to([]))
+            assert_that(output[None], equal_to([]))
 
         bucket_contents = collect_bucket_contents(self.s3_client, self.bucket_name)
         self.assertSetEqual(set(bucket_contents), set(["onetwo", "threefour"]))
@@ -188,9 +220,13 @@ class TestWriteToFirehose(unittest.TestCase):
                 p
                 | beam.Create(["one", "two", "three", "four"])
                 | BatchElements(min_batch_size=2, max_batch_size=2)
-                | WriteToFirehose(self.delivery_stream_name, False, True)
+                | WriteToFirehose(
+                    delivery_stream_name=self.delivery_stream_name,
+                    jsonify=False,
+                    multiline=True,
+                )
             )
-            assert_that(output, equal_to([]))
+            assert_that(output[None], equal_to([]))
 
         bucket_contents = collect_bucket_contents(self.s3_client, self.bucket_name)
         self.assertSetEqual(set(bucket_contents), set(["one\ntwo\n", "three\nfour\n"]))
@@ -201,15 +237,22 @@ class TestWriteToFirehose(unittest.TestCase):
                 p
                 | beam.Create([(1, "one"), (2, "three"), (1, "two"), (2, "four")])
                 | GroupIntoBatches(batch_size=2)
-                | WriteToFirehose(self.delivery_stream_name, False, True)
+                | WriteToFirehose(
+                    delivery_stream_name=self.delivery_stream_name,
+                    jsonify=False,
+                    multiline=True,
+                )
             )
-            assert_that(output, equal_to([]))
+            assert_that(output[None], equal_to([]))
 
         bucket_contents = collect_bucket_contents(self.s3_client, self.bucket_name)
         self.assertSetEqual(set(bucket_contents), set(["one\ntwo\n", "three\nfour\n"]))
 
 
 class TestRetryLogic(unittest.TestCase):
+    # default failed output name
+    failed_output = "write-to-firehose-failed-output"
+
     def test_write_to_firehose_retry_with_no_failed_element(self):
         with TestPipeline() as p:
             output = (
@@ -217,25 +260,60 @@ class TestRetryLogic(unittest.TestCase):
                 | beam.Create(["one", "two", "three", "four"])
                 | BatchElements(min_batch_size=4)
                 | WriteToFirehose(
-                    "non-existing-delivery-stream", False, False, 3, {"num_success": 2}
+                    delivery_stream_name="non-existing-delivery-stream",
+                    jsonify=False,
+                    multiline=False,
+                    max_trials=3,
+                    append_error=False,
+                    fake_config={"num_success": 2},
                 )
             )
-            assert_that(output, equal_to([]))
+            assert_that(output[self.failed_output], equal_to([]))
 
-    def test_write_to_firehose_retry_with_failed_elements(self):
+    def test_write_to_firehose_retry_failed_element_without_appending_error(self):
         with TestPipeline() as p:
             output = (
                 p
                 | beam.Create(["one", "two", "three", "four"])
                 | BatchElements(min_batch_size=4)
                 | WriteToFirehose(
-                    "non-existing-delivery-stream", False, False, 3, {"num_success": 1}
+                    delivery_stream_name="non-existing-delivery-stream",
+                    jsonify=False,
+                    multiline=False,
+                    max_trials=3,
+                    append_error=False,
+                    fake_config={"num_success": 1},
                 )
             )
-            assert_that(output, equal_to(["four"]))
+            assert_that(output[self.failed_output], equal_to(["four"]))
+
+    def test_write_to_firehose_retry_failed_element_with_appending_error(self):
+        with TestPipeline() as p:
+            output = (
+                p
+                | beam.Create(["one", "two", "three", "four"])
+                | BatchElements(min_batch_size=4)
+                | WriteToFirehose(
+                    delivery_stream_name="non-existing-delivery-stream",
+                    jsonify=False,
+                    multiline=False,
+                    max_trials=3,
+                    append_error=True,
+                    fake_config={"num_success": 1},
+                )
+            )
+            assert_that(
+                output[self.failed_output],
+                equal_to(
+                    [("four", {"ErrorCode": "Error", "ErrorMessage": "This error"})]
+                ),
+            )
 
 
 class TestMetrics(unittest.TestCase):
+    # default failed output name
+    failed_output = "write-to-firehose-failed-output"
+
     def test_metrics_with_no_failed_element(self):
         pipeline = TestPipeline()
         output = (
@@ -243,10 +321,15 @@ class TestMetrics(unittest.TestCase):
             | beam.Create(["one", "two", "three", "four"])
             | BatchElements(min_batch_size=4)
             | WriteToFirehose(
-                "non-existing-delivery-stream", False, False, 3, {"num_success": 2}
+                delivery_stream_name="non-existing-delivery-stream",
+                jsonify=False,
+                multiline=False,
+                max_trials=3,
+                fake_config={"num_success": 2},
             )
         )
-        assert_that(output, equal_to([]))
+        assert_that(output[None], equal_to([]), label="TestMain")
+        assert_that(output[self.failed_output], equal_to([]), label="TestFailed")
 
         res = pipeline.run()
         res.wait_until_finish()
@@ -284,10 +367,16 @@ class TestMetrics(unittest.TestCase):
             | beam.Create(["one", "two", "three", "four"])
             | BatchElements(min_batch_size=4)
             | WriteToFirehose(
-                "non-existing-delivery-stream", False, False, 3, {"num_success": 1}
+                delivery_stream_name="non-existing-delivery-stream",
+                jsonify=False,
+                multiline=False,
+                max_trials=3,
+                append_error=False,
+                fake_config={"num_success": 1},
             )
         )
-        assert_that(output, equal_to(["four"]))
+        assert_that(output[None], equal_to([]), label="TestMain")
+        assert_that(output[self.failed_output], equal_to(["four"]), label="TestFailed")
 
         res = pipeline.run()
         res.wait_until_finish()


### PR DESCRIPTION
- add option to append error details if failed records
- tagged output for failed records
- fix errors in docstring and readme
- no TypeError, only FirehoseClientError
- add logging in the dofn